### PR TITLE
move to debian to avoid socat bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
-FROM alpine:latest
-RUN apk add socat
-CMD ["socat", "-v", "udp-l:1235,fork,bind=fly-global-services", "exec:/bin/cat"]
+FROM debian:latest
+
+# Update the package list and install socat
+RUN apt-get update && \
+    apt-get install -y socat && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set the command to be executed when running the container
+CMD ["socat", "-v", "udp-l:1235,fork,bind=fly-global-services", "exec: /bin/cat"]


### PR DESCRIPTION
getting error found in https://github.com/termux/termux-packages/issues/18645, so I switched to debian, which worked.

previously, this would crash with: 

```
socat[1] E xioopen_ipdgram_listen(): unknown address family 0
```